### PR TITLE
Include docs for buffalo-pop

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 
   * install golang
   * acquire buffallo tool - `go get -u -v github.com/gobuffalo/buffalo/buffalo`
+  * acquire buffalo-pop - `buffalo plugins install github.com/gobuffalo/buffalo-pop`
   * optionally consider installing bash completion: https://gobuffalo.io/en/docs/getting-started/integrations
   * setup database - `buffalo pop create -a` (amend database.yml if needed)
   * run server `buffalo dev`

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@
 
   * install golang
   * acquire buffallo tool - `go get -u -v github.com/gobuffalo/buffalo/buffalo`
-  * acquire buffalo-pop - `buffalo plugins install github.com/gobuffalo/buffalo-pop`
+  * acquire buffalo-pop:
+    * `buffalo plugins install github.com/gobuffalo/buffalo-pop`; or,
+    * `go get -u -v github.com/gobuffalo/buffalo-pop`
   * optionally consider installing bash completion: https://gobuffalo.io/en/docs/getting-started/integrations
   * setup database - `buffalo pop create -a` (amend database.yml if needed)
   * run server `buffalo dev`


### PR DESCRIPTION
Current instructions lead to an error:

`````
buffalo pop create -a                                                                                              2  22:55:09 
ERRO[0000] Pop support has been moved to the https://github.com/gobuffalo/buffalo-pop plugin.

!! PLEASE READ PLUGIN DOCUMENTATION - https://gobuffalo.io/en/docs/plugins

Buffalo Plugins Installation*:

	$ buffalo plugins install github.com/gobuffalo/buffalo-pop
`````